### PR TITLE
Fix code lens implementation resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules
 
 .vscode
 .idea
+.pre-commit-config.yaml
+trufflehog/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@types/glob": "^8.0.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "16.x",
-        "@types/vscode": "^1.74.0",
+        "@types/vscode": "^1.95.0",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
         "@vscode/test-electron": "^2.2.0",
@@ -24,7 +24,7 @@
         "webpack-cli": "^5.0.0"
       },
       "engines": {
-        "vscode": "^1.74.0"
+        "vscode": "^1.95.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -261,10 +261,11 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
-      "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
-      "dev": true
+      "version": "1.102.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.102.0.tgz",
+      "integrity": "sha512-V9sFXmcXz03FtYTSUsYsu5K0Q9wH9w9V25slddcxrh5JgORD14LpnOA7ov0L9ALi+6HrTjskLJ/tY5zeRF3TFA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.48.0",
@@ -3773,9 +3774,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
-      "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
+      "version": "1.102.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.102.0.tgz",
+      "integrity": "sha512-V9sFXmcXz03FtYTSUsYsu5K0Q9wH9w9V25slddcxrh5JgORD14LpnOA7ov0L9ALi+6HrTjskLJ/tY5zeRF3TFA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "version": "0.1.0",
   "publisher": "galkowskit",
   "engines": {
-    "vscode": "^1.74.0"
+    "vscode": "^1.95.0"
   },
   "categories": [
     "Other"
@@ -30,7 +30,7 @@
     "@types/glob": "^8.0.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
-    "@types/vscode": "^1.74.0",
+    "@types/vscode": "^1.95.0",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
     "@vscode/test-electron": "^2.2.0",

--- a/src/AnnotateLensProvider.ts
+++ b/src/AnnotateLensProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { Annotation } from "./Annotation";
 import { AnnotationLens } from "./AnnotationLens";
-import { SymbolInfo } from "./SymbolInfo";
+import { SymbolInfo, LocatedSymbol } from "./SymbolInfo";
 
 export class AnnotationLensProvider
   implements vscode.CodeLensProvider<AnnotationLens>
@@ -14,12 +14,9 @@ export class AnnotationLensProvider
     const results: AnnotationLens[] = [];
     for (const goSymbol of goSymbols) {
       const symbolInfo = await SymbolInfo.create(goSymbol);
-      const activeEditor = vscode.window.activeTextEditor;
-      if (!activeEditor) {
-        return [];
-      }
 
-      const locations = await this.getSymbolLocations(activeEditor, symbolInfo) ?? [];
+      const locations =
+        (await this.getSymbolLocations(document, symbolInfo)) ?? [];
       const symbols = await Promise.all(locations.map(SymbolInfo.getSymbol));
       if (symbols.length === 0) {
         continue;
@@ -32,23 +29,41 @@ export class AnnotationLensProvider
     return results;
   }
 
-  private async getSymbolLocations(te: vscode.TextEditor, si: SymbolInfo): Promise<vscode.Location[]> {
+  private async getSymbolLocations(
+    document: vscode.TextDocument,
+    si: SymbolInfo
+  ): Promise<vscode.Location[]> {
     return vscode.commands.executeCommand<vscode.Location[]>(
       "vscode.executeImplementationProvider",
-      te.document.uri,
+      document.uri,
       si.symbol.location.range.start
     );
   }
 
-  private async getGoSymbols(document: vscode.TextDocument) {
-    const symbols = (await vscode.commands.executeCommand<
-      (vscode.SymbolInformation & vscode.DocumentSymbol)[]
-    >("vscode.executeDocumentSymbolProvider", document.uri))!.filter(
-      (symbol) =>
-        symbol.kind === vscode.SymbolKind.Class ||
-        symbol.kind === vscode.SymbolKind.Struct ||
-        symbol.kind === vscode.SymbolKind.Interface
-    );
-    return symbols;
+  private async getGoSymbols(
+    document: vscode.TextDocument
+  ): Promise<LocatedSymbol[]> {
+    const symbols =
+      (await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+        "vscode.executeDocumentSymbolProvider",
+        document.uri
+      )) ?? [];
+
+    const flatten = (sym: vscode.DocumentSymbol[]): vscode.DocumentSymbol[] =>
+      sym.flatMap((s) => [s, ...flatten(s.children || [])]);
+
+    return flatten(symbols)
+      .filter(
+        (symbol) =>
+          symbol.kind === vscode.SymbolKind.Class ||
+          symbol.kind === vscode.SymbolKind.Struct ||
+          symbol.kind === vscode.SymbolKind.Interface
+      )
+      .map(
+        (symbol) => ({
+          ...symbol,
+          location: new vscode.Location(document.uri, symbol.range),
+        }) as LocatedSymbol
+      );
   }
 }

--- a/src/Annotation.ts
+++ b/src/Annotation.ts
@@ -1,8 +1,8 @@
-import * as vscode from "vscode";
+import type { LocatedSymbol } from "./SymbolInfo";
 
 export class Annotation {
   public constructor(
-    public readonly from: vscode.SymbolInformation & vscode.DocumentSymbol,
-    public readonly to: Array<vscode.SymbolInformation & vscode.DocumentSymbol>
+    public readonly from: LocatedSymbol,
+    public readonly to: Array<LocatedSymbol>
   ) {}
 }

--- a/src/SymbolInfo.ts
+++ b/src/SymbolInfo.ts
@@ -1,29 +1,48 @@
 import * as vscode from "vscode";
 
-export class SymbolInfo {
-  public readonly symbol: vscode.SymbolInformation & vscode.DocumentSymbol;
+export interface LocatedSymbol extends vscode.DocumentSymbol {
+  location: vscode.Location;
+}
 
-  public static async create(
-    symbol: vscode.SymbolInformation & vscode.DocumentSymbol
-  ): Promise<SymbolInfo> {
+export class SymbolInfo {
+  public readonly symbol: LocatedSymbol;
+
+  public static async create(symbol: LocatedSymbol): Promise<SymbolInfo> {
     const createdSymbolInfo = new SymbolInfo(symbol);
     return createdSymbolInfo;
   }
 
-  public static async getSymbol(
-    location: vscode.Location
-  ): Promise<vscode.SymbolInformation & vscode.DocumentSymbol> {
-    const documentSymbols = (await vscode.commands.executeCommand<
-      (vscode.SymbolInformation & vscode.DocumentSymbol)[]
-    >("vscode.executeDocumentSymbolProvider", location.uri))!;
-    return documentSymbols.find((documentSymbol) =>
-      documentSymbol.range.start.isEqual(location.range.start)
-    ) as vscode.SymbolInformation & vscode.DocumentSymbol;
+  public static async getSymbol(location: vscode.Location): Promise<LocatedSymbol> {
+    const documentSymbols =
+      (await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+        "vscode.executeDocumentSymbolProvider",
+        location.uri
+      )) ?? [];
+
+    const findSymbol = (
+      symbols: vscode.DocumentSymbol[]
+    ): vscode.DocumentSymbol | undefined => {
+      for (const symbol of symbols) {
+        if (symbol.range.start.isEqual(location.range.start)) {
+          return symbol;
+        }
+        const child = findSymbol(symbol.children || []);
+        if (child) {
+          return child;
+        }
+      }
+      return undefined;
+    };
+
+    const found = findSymbol(documentSymbols);
+    if (!found) {
+      throw new Error("Symbol not found");
+    }
+
+    return { ...found, location } as LocatedSymbol;
   }
 
-  private constructor(
-    symbol: vscode.SymbolInformation & vscode.DocumentSymbol
-  ) {
+  private constructor(symbol: LocatedSymbol) {
     this.symbol = symbol;
 
     if (

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,14 @@
 import * as vscode from "vscode";
 import { AnnotationLensProvider } from "./AnnotateLensProvider";
 
+export const output = vscode.window.createOutputChannel(
+  "Go Interface Annotations"
+);
+
 export function activate(context: vscode.ExtensionContext) {
+  context.subscriptions.push(output);
+  output.appendLine("Go Interface Annotations activated");
+
   context.subscriptions.push(
     vscode.languages.registerCodeLensProvider(
       [{ language: "go" }],


### PR DESCRIPTION
## Summary
- handle DocumentSymbol results and recursively resolve symbols
- add output channel for logs
- upgrade VS Code engine and types to 1.95

## Testing
- `npm run lint`
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_688dc81342cc8323b0107cc41cad944a